### PR TITLE
fix: controller now returns json instead of json string

### DIFF
--- a/src/controllers/EntryTypesController.php
+++ b/src/controllers/EntryTypesController.php
@@ -37,15 +37,12 @@ class EntryTypesController extends Controller
 
         $entryTypes = LevelEntryTypes::$plugin->levelEntryTypesService->getDisabledEntryTypes($sectionId, $level);
 
-        $result = json_encode([
+        return $this->asJson([
             'parentId' => $parentId, 
             'sectionId' => $sectionId, 
             'parentLevel' => $level,
             'disabledEntryTypes' => $entryTypes
-
         ]);
-
-        return $result;
     }
 
     public function actionMap()


### PR DESCRIPTION
Hi

I encountered the same issue as #5. 

Upon troubleshooting, I found that the controller was returning a JSON string instead of a JSON object. The JS looked for the `disabledEntryTypes` property on the response, which was never present since it was just a string. 

Not sure why some servers returned the JSON and some only returned the string, but it should be fixed now, by using the craft controller's `asJson()` method.